### PR TITLE
security: add auth and rate limiting to leak-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,32 @@
 ### 🚀 开发
 使用我们的安装脚本, 快速构建开发环境.
 ```bash
-curl -LsSf https://raw.githubusercontent.com/garinasset/leak-check/refs/heads/main/install.sh | bash
+git clone https://github.com/pa4uslf/leak-check.git
+cd leak-check
+./install.sh
+```
+
+### 🔐 安全配置
+
+服务启动前至少配置以下环境变量:
+
+```bash
+export LEAK_CHECK_API_KEYS="replace-with-long-random-token"
+export LEAK_CHECK_ALLOWED_ORIGINS="https://your-console.example.com"
+```
+
+- `LEAK_CHECK_API_KEYS`: 逗号分隔的 API Key 列表；`/` 与 `/dig/masking` 现在都必须携带。
+- `LEAK_CHECK_ALLOWED_ORIGINS`: 允许跨域的前端来源；未配置时仅允许本地开发源。
+- `LEAK_CHECK_RATE_LIMIT`: 可选，默认每个 IP 每 60 秒 30 次查询。
+- `LEAK_CHECK_RATE_WINDOW_SECONDS`: 可选，默认 60 秒。
+
+调用示例:
+
+```bash
+curl -X POST http://127.0.0.1:3001/leak-check/dig/masking \
+  -H "Authorization: Bearer replace-with-long-random-token" \
+  -H "Content-Type: application/json" \
+  -d '{"q":"13800138000"}'
 ```
 
 ### 📊 数据库

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
-import re
 from typing import Sequence
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends, Request
 from starlette.middleware.cors import CORSMiddleware
 from starlette.responses import PlainTextResponse
 
@@ -9,10 +8,10 @@ from db import crud
 from db.crud import SessionDep
 from models.database import Person
 from models.request import ModelRequestQuery
-from models.response import ModelResponsePersonAggregated, ModelResponsePersonAggregatedMasking
+from models.response import ModelResponsePersonAggregatedMasking
 
-from lib.aggregation import clean_str_set, clean_int_set, clean_id_set
 from lib.masking import mask_list
+from security import RATE_LIMIT, get_client_ip, resolve_allowed_origins, verify_api_key
 
 app = FastAPI(
     root_path="/leak-check",
@@ -33,9 +32,9 @@ app = FastAPI(
 # 允许跨域
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_origins=resolve_allowed_origins(),
+    allow_methods=["GET", "POST"],
+    allow_headers=["Authorization", "Content-Type", "X-API-Key"],
 )
 
 
@@ -67,7 +66,7 @@ async def root():
              }
          }
          )
-async def get_counts(session: SessionDep):
+async def get_counts(session: SessionDep, _=Depends(verify_api_key)):
     counts = crud.read_counts(session=session)
     return counts
 
@@ -77,7 +76,8 @@ async def get_counts(session: SessionDep):
     summary="查询 个人信息“泄漏” 记录 - 脱敏",
     response_model=ModelResponsePersonAggregatedMasking,
 )
-def get_person_by_dig(body: ModelRequestQuery, session: SessionDep):
+def get_person_by_dig(body: ModelRequestQuery, request: Request, session: SessionDep, _=Depends(verify_api_key)):
+    RATE_LIMIT.check(get_client_ip(request))
     persons: Sequence[Person] = []
 
     match body.type:

--- a/security.py
+++ b/security.py
@@ -1,0 +1,74 @@
+import os
+import time
+import hmac
+import threading
+from collections import defaultdict, deque
+
+from fastapi import HTTPException, Request
+
+
+def resolve_allowed_origins() -> list[str]:
+    configured = os.getenv("LEAK_CHECK_ALLOWED_ORIGINS", "").strip()
+    if configured:
+        return [origin.strip() for origin in configured.split(",") if origin.strip()]
+    return [
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+        "http://localhost:3001",
+        "http://127.0.0.1:3001",
+    ]
+
+
+def verify_api_key(request: Request) -> None:
+    configured = [
+        token.strip()
+        for token in os.getenv("LEAK_CHECK_API_KEYS", "").split(",")
+        if token.strip()
+    ]
+    if not configured:
+        raise HTTPException(status_code=503, detail="Server authentication is not configured")
+
+    presented = request.headers.get("X-API-Key", "").strip()
+    auth_header = request.headers.get("Authorization", "").strip()
+    if not presented and auth_header.startswith("Bearer "):
+        presented = auth_header[7:].strip()
+
+    if not presented:
+        raise HTTPException(status_code=401, detail="Missing API key")
+
+    if any(hmac.compare_digest(presented, expected) for expected in configured):
+        return
+
+    raise HTTPException(status_code=401, detail="Invalid API key")
+
+
+class InMemoryRateLimiter:
+    def __init__(self, limit: int, window_seconds: int) -> None:
+        self.limit = limit
+        self.window_seconds = window_seconds
+        self._events: dict[str, deque[float]] = defaultdict(deque)
+        self._lock = threading.Lock()
+
+    def check(self, key: str) -> None:
+        now = time.time()
+        cutoff = now - self.window_seconds
+        with self._lock:
+            bucket = self._events[key]
+            while bucket and bucket[0] < cutoff:
+                bucket.popleft()
+            if len(bucket) >= self.limit:
+                raise HTTPException(status_code=429, detail="Too many requests")
+            bucket.append(now)
+
+
+def get_client_ip(request: Request) -> str:
+    forwarded_for = request.headers.get("X-Forwarded-For", "").strip()
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+RATE_LIMIT = InMemoryRateLimiter(
+    limit=int(os.getenv("LEAK_CHECK_RATE_LIMIT", "30")),
+    window_seconds=int(os.getenv("LEAK_CHECK_RATE_WINDOW_SECONDS", "60")),
+)

--- a/uvicorn-leak-check.service
+++ b/uvicorn-leak-check.service
@@ -9,6 +9,10 @@ WorkingDirectory=/home/debian/leak-check
 
 # 环境变量
 Environment="PATH=/home/debian/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
+Environment="LEAK_CHECK_API_KEYS=replace-with-long-random-token"
+Environment="LEAK_CHECK_ALLOWED_ORIGINS=https://your-console.example.com"
+Environment="LEAK_CHECK_RATE_LIMIT=30"
+Environment="LEAK_CHECK_RATE_WINDOW_SECONDS=60"
 
 # 启动命令
 ExecStart=/home/debian/.local/bin/uv run uvicorn main:app --host 0.0.0.0 --port 3001  --workers 4


### PR DESCRIPTION
## Summary
- require API key auth for sensitive endpoints
- add per-IP in-memory rate limiting to query requests
- replace wildcard CORS with configurable allowed origins
- document required deployment environment variables

## Validation
- ran `python3 -m py_compile main.py security.py db/crud.py models/request.py models/response.py lib/masking.py`
